### PR TITLE
fix: resolve virtuals for monorepos

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,11 @@ const resolve = (source, file) => {
     }
 
     try {
-        return { found: true, path: require.resolve(source, { paths: [path.dirname(file)] }) }
+        let moduleId = require.resolve(source, { paths: [path.dirname(file)] })
+        if (process.versions.pnp && moduleId.includes('__virtual__')) {
+            moduleId = require('pnpapi').resolveVirtual(moduleId)
+        }
+        return { found: true, path: moduleId }
     } catch (err) {
         return { found: false }
     }


### PR DESCRIPTION
## Description

In monorepos using yarn 2+, virtual imports can cause issues with how sibling imports work. This change will only affect virtual imports where require pnp is enabled. If the import is virtual, it will resolve the virtual import.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/eslint-import-resolver-require/blob/master/CODE_OF_CONDUCT.md).
- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
